### PR TITLE
Bruk appnavn namespace

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/count/EventCounterServiceTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/count/EventCounterServiceTestIT.kt
@@ -6,6 +6,8 @@ import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.internal.periodic.metrics.reporter.common.HandlerConsumer
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.EventCountForProducer
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.cache.count.CacheCountingMetricsProbe
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.cache.count.CacheCountingMetricsSession
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.cache.count.CacheEventCounterService
@@ -16,9 +18,11 @@ internal class EventCounterServiceTestIT {
 
     private val handlerConsumer = mockk<HandlerConsumer>()
 
+    private val commonNamespace = "namespace"
+
     @Test
     fun `Should count beskjed events`() {
-        val appnavne = listOf("b_appnavn_A", "b_appnavn_B")
+        val appnavne = createProducers("b_appnavn_A", "b_appnavn_B")
         val result = createResult(appnavne)
         coEvery { handlerConsumer.getEventCount(any()) }.returns(result)
 
@@ -38,7 +42,7 @@ internal class EventCounterServiceTestIT {
 
     @Test
     fun `Should count innboks events`() {
-        val appnavne = listOf("i_appnavn_A", "i_appnavn_B")
+        val appnavne = createProducers("i_appnavn_A", "i_appnavn_B")
         val result = createResult(appnavne)
         coEvery { handlerConsumer.getEventCount(any()) }.returns(result)
 
@@ -58,7 +62,7 @@ internal class EventCounterServiceTestIT {
 
     @Test
     fun `Should count oppgave events`() {
-        val appnavne = listOf("o_appnavn_A", "o_appnavn_B")
+        val appnavne = createProducers("o_appnavn_A", "o_appnavn_B")
         val result = createResult(appnavne)
         coEvery { handlerConsumer.getEventCount(any()) }.returns(result)
 
@@ -78,7 +82,7 @@ internal class EventCounterServiceTestIT {
 
     @Test
     fun `Should count done events`() {
-        val appnavne = listOf("d_appnavn_A", "d_appnavn_B")
+        val appnavne = createProducers("d_appnavn_A", "d_appnavn_B")
         val result = createResult(appnavne)
         coEvery { handlerConsumer.getEventCount(any()) }.returns(result)
 
@@ -112,13 +116,16 @@ internal class EventCounterServiceTestIT {
         }
     }
 
-    private fun createResult(appnavne: List<String>): Map<String, Int> {
-        val result = mutableMapOf<String, Int>()
-
-        appnavne.forEach { appnavn ->
-            result.put(appnavn, 1)
+    fun createProducers(vararg producerNames: String): List<Producer> {
+        return producerNames.map { producerName ->
+            Producer(commonNamespace, producerName)
         }
-        return result
+    }
+
+    private fun createResult(producers: List<Producer>): List<EventCountForProducer> {
+        return producers.map { producer ->
+            EventCountForProducer(producer.namespace, producer.appName, 1)
+        }
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/common/HandlerConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/common/HandlerConsumer.kt
@@ -3,21 +3,22 @@ package no.nav.personbruker.internal.periodic.metrics.reporter.common
 import io.ktor.client.*
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.get
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.EventCountForProducer
 import org.slf4j.LoggerFactory
 import java.net.URL
 
 class HandlerConsumer(private val client: HttpClient, private val azureTokenFetcher: AzureTokenFetcher, private val eventHandlerBaseURL: String) {
     private val log = LoggerFactory.getLogger(HandlerConsumer::class.java)
 
-    suspend fun getEventCount(eventtype: EventType): Map<String, Int> {
+    suspend fun getEventCount(eventtype: EventType): List<EventCountForProducer> {
         try {
-            val pathToEndpoint = URL("$eventHandlerBaseURL/fetch/grouped/systemuser/" +
-                    eventtype.eventType.replace("_intern", ""))
+            val pathToEndpoint = URL("$eventHandlerBaseURL/fetch/grouped/produsent/${eventtype.originalType}")
 
             return client.get(pathToEndpoint, azureTokenFetcher)
         } catch (e: Exception) {
-            log.error("Får ikke kontakt med dittnav-event-handler. Setter derfor produsentnavnet til <appnavn_unavailable> og antall event = 0.", e)
-            return mapOf("appnavn_unavailable" to 0)
+            log.error("Får ikke kontakt med dittnav-event-handler.", e)
+            return emptyList()
         }
     }
 }
+

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/common/HandlerConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/common/HandlerConsumer.kt
@@ -12,7 +12,7 @@ class HandlerConsumer(private val client: HttpClient, private val azureTokenFetc
 
     suspend fun getEventCount(eventtype: EventType): List<EventCountForProducer> {
         try {
-            val pathToEndpoint = URL("$eventHandlerBaseURL/fetch/grouped/produsent/${eventtype.originalType}")
+            val pathToEndpoint = URL("$eventHandlerBaseURL/fetch/grouped/producer/${eventtype.originalType}")
 
             return client.get(pathToEndpoint, azureTokenFetcher)
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/config/EventType.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/config/EventType.kt
@@ -1,9 +1,13 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.config
 
-enum class EventType(val eventType: String) {
-    OPPGAVE_INTERN("oppgave_intern"),
-    BESKJED_INTERN("beskjed_intern"),
-    INNBOKS_INTERN("innboks_intern"),
-    STATUSOPPDATERING_INTERN("statusoppdatering_intern"),
-    DONE_INTERN("done_intern")
+enum class EventType(val originalType: String) {
+
+    OPPGAVE_INTERN("oppgave"),
+
+    BESKJED_INTERN("beskjed"),
+    INNBOKS_INTERN("innboks"),
+    STATUSOPPDATERING_INTERN("statusoppdatering"),
+    DONE_INTERN("done");
+
+    val eventType = "${originalType}_intern"
 }

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/DiscrepancyMetricsReporter.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/DiscrepancyMetricsReporter.kt
@@ -46,14 +46,18 @@ class DiscrepancyMetricsReporter(private val metricsReporter: MetricsReporter) {
         }
     }
 
-    private suspend fun reportEvents(count: Int, eventType: String, producerName: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerName))
+    private suspend fun reportEvents(count: Int, eventType: String, producer: Producer, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producer))
     }
 
     private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
 
-    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
-        listOf("eventType" to eventType, "producer" to producer).toMap()
+    private fun createTagMap(eventType: String, producer: Producer): Map<String, String> =
+        listOf(
+            "eventType" to eventType,
+            "producer" to producer.appName,
+            "producerNamespace" to producer.namespace
+        ).toMap()
 
     private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
         metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/EventCountForProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/EventCountForProducer.kt
@@ -1,0 +1,9 @@
+package no.nav.personbruker.internal.periodic.metrics.reporter.metrics
+
+data class EventCountForProducer(
+    val namespace: String,
+    val appName: String,
+    val count: Int
+) {
+    val producer get() = Producer(namespace, appName)
+}

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/Producer.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/Producer.kt
@@ -1,0 +1,10 @@
+package no.nav.personbruker.internal.periodic.metrics.reporter.metrics
+
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.KafkaEventIdentifier
+
+data class Producer(
+    val namespace: String,
+    val appName: String
+)
+
+val KafkaEventIdentifier.producer get() = Producer(namespace, appnavn)

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheMetricsReporter.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheMetricsReporter.kt
@@ -5,6 +5,7 @@ import no.nav.personbruker.internal.periodic.metrics.reporter.common.exceptions.
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.DB_COUNT_PROCESSING_TIME
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.DB_TOTAL_EVENTS_IN_CACHE
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import org.slf4j.LoggerFactory
 
 class CacheMetricsReporter(private val metricsReporter: MetricsReporter) {
@@ -52,16 +53,20 @@ class CacheMetricsReporter(private val metricsReporter: MetricsReporter) {
         reportProcessingTimeEvent(session)
     }
 
-    private suspend fun reportEvents(count: Int, eventType: String, producerName: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerName))
+    private suspend fun reportEvents(count: Int, eventType: String, producer: Producer, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producer))
     }
 
     private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
 
     private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
 
-    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
-            listOf("eventType" to eventType, "producer" to producer).toMap()
+    private fun createTagMap(eventType: String, producer: Producer): Map<String, String> =
+            listOf(
+                "eventType" to eventType,
+                "producer" to producer.appName,
+                "producerNamespace" to producer.namespace
+            ).toMap()
 
     private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
         metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/KafkaEventIdentifier.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/KafkaEventIdentifier.kt
@@ -1,19 +1,24 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka
 
-data class KafkaEventIdentifier(val eventId: String, val appnavn: String) {
+data class KafkaEventIdentifier(
+    val eventId: String,
+    val namespace: String,
+    val appnavn: String
+) {
 
     companion object {
 
         fun createInvalidEvent(): KafkaEventIdentifier {
             return KafkaEventIdentifier(
                     "undeserializableEvent",
-                    "unknownProducer"
+                    "unknownProducerNamespace",
+                    "unknownProducerAppName"
             )
         }
     }
 
     override fun toString(): String {
-        return "UniqueKafkaEventIdentifier(eventId='$eventId', appnavn='$appnavn)"
+        return "UniqueKafkaEventIdentifier(eventId='$eventId', namespace='$namespace', appnavn='$appnavn')"
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/KafkaKeyIdentifierTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/KafkaKeyIdentifierTransformer.kt
@@ -20,7 +20,7 @@ object KafkaKeyIdentifierTransformer {
                 invalidEvent
             }
             is NokkelIntern -> {
-                KafkaEventIdentifier(key.getEventId(), key.getAppnavn())
+                KafkaEventIdentifier(key.getEventId(), key.getNamespace(), key.getAppnavn())
             }
             else -> {
                 val invalidEvent = KafkaEventIdentifier.createInvalidEvent()

--- a/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSession.kt
@@ -2,13 +2,15 @@ package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.top
 
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.CountingMetricsSession
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.KafkaEventIdentifier
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.producer
 
 class TopicMetricsSession : CountingMetricsSession {
 
     val eventType: EventType
 
-    private var numberOfEventsByProducer: MutableMap<String, Int>
+    private var numberOfEventsByProducer: MutableMap<Producer, Int>
 
     private val start = System.nanoTime()
     private var processingTime : Long = 0L
@@ -24,19 +26,19 @@ class TopicMetricsSession : CountingMetricsSession {
     }
 
     fun countEvent(event: KafkaEventIdentifier) {
-        val produsent = event.appnavn
+        val produsent = event.producer
         numberOfEventsByProducer[produsent] = numberOfEventsByProducer.getOrDefault(produsent, 0).inc()
     }
 
-    fun getNumberOfEventsForProducer(prodcer: String): Int {
-        return numberOfEventsByProducer.getOrDefault(prodcer, 0)
+    fun getNumberOfEventsForProducer(producer: Producer): Int {
+        return numberOfEventsByProducer.getOrDefault(producer, 0)
     }
 
     override fun getNumberOfEvents(): Int {
         return numberOfEventsByProducer.values.sum()
     }
 
-    fun getProducersWithEvents(): Set<String> {
+    fun getProducersWithEvents(): Set<Producer> {
         return numberOfEventsByProducer.keys
     }
 

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/DiscrepancyMetricsReporterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/DiscrepancyMetricsReporterTest.kt
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test
 
 internal class DiscrepancyMetricsReporterTest {
 
-    private val producer1 = "producer1"
-    private val producer2 = "producer2"
+    private val producer1 = Producer("namespace1", "producer1")
+    private val producer2 = Producer("namespace2", "producer2")
 
     private val metricsReporter: MetricsReporter = mockk()
 

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheCountingMetricsSessionObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheCountingMetricsSessionObjectMother.kt
@@ -1,62 +1,60 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.cache.count
 
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
-import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.KafkaEventIdentifier
-import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.topic.TopicMetricsSession
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.EventCountForProducer
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 
 object CacheCountingMetricsSessionObjectMother {
 
+    private const val defaultNamespace = "producerNamespace"
+
     fun giveMeBeskjedInternSessionWithOneCountedEvent(): CacheCountingMetricsSession {
         val beskjedInternSession = CacheCountingMetricsSession(EventType.BESKJED_INTERN)
-        beskjedInternSession.addEventsByProducer(mapOf("produsent1" to 1))
+        beskjedInternSession.addEventsByProducer(createCount("produsent1", 1))
         return beskjedInternSession
     }
 
     fun giveMeBeskjedInternSessionWithTwoCountedEvent(): CacheCountingMetricsSession {
         val beskjedInternSession = CacheCountingMetricsSession(EventType.BESKJED_INTERN)
-        beskjedInternSession.addEventsByProducer(mapOf("produsent1" to 11))
-        beskjedInternSession.addEventsByProducer(mapOf("produsent1" to 12))
+        beskjedInternSession.addEventsByProducer(createCount("produsent1", 2))
         return beskjedInternSession
     }
 
     fun giveMeDoneInternSessionWithTwoCountedEvents(): CacheCountingMetricsSession {
         val doneInternSession = CacheCountingMetricsSession(EventType.DONE_INTERN)
-        doneInternSession.addEventsByProducer(mapOf("produsent2" to 21))
-        doneInternSession.addEventsByProducer(mapOf("produsent2" to 22))
+        doneInternSession.addEventsByProducer(createCount("produsent2", 2))
         return doneInternSession
     }
 
     fun giveMeInnboksInternSessionWithThreeCountedEvents(): CacheCountingMetricsSession {
         val innboksInternSession = CacheCountingMetricsSession(EventType.INNBOKS_INTERN)
-        innboksInternSession.addEventsByProducer(mapOf("produsent3" to 31))
-        innboksInternSession.addEventsByProducer(mapOf("produsent3" to 32))
-        innboksInternSession.addEventsByProducer(mapOf("produsent3" to 33))
+        innboksInternSession.addEventsByProducer(createCount("produsent3", 3))
         return innboksInternSession
     }
 
     fun giveMeOppgaveInternSessionWithFourCountedEvents(): CacheCountingMetricsSession {
         val oppgaveInternSession = CacheCountingMetricsSession(EventType.OPPGAVE_INTERN)
-        oppgaveInternSession.addEventsByProducer(mapOf("produsent4" to 41))
-        oppgaveInternSession.addEventsByProducer(mapOf("produsent4" to 42))
-        oppgaveInternSession.addEventsByProducer(mapOf("produsent4" to 43))
-        oppgaveInternSession.addEventsByProducer(mapOf("produsent4" to 44))
+        oppgaveInternSession.addEventsByProducer(createCount("produsent4", 4))
         return oppgaveInternSession
     }
 
     fun giveMeStatusoppdateringInternSessionWithFourCountedEvents(): CacheCountingMetricsSession {
         val statusoppdateringInternSession = CacheCountingMetricsSession(EventType.STATUSOPPDATERING_INTERN)
-        statusoppdateringInternSession.addEventsByProducer(mapOf("produsent5" to 51))
-        statusoppdateringInternSession.addEventsByProducer(mapOf("produsent5" to 52))
-        statusoppdateringInternSession.addEventsByProducer(mapOf("produsent5" to 53))
-        statusoppdateringInternSession.addEventsByProducer(mapOf("produsent5" to 54))
+        statusoppdateringInternSession.addEventsByProducer(createCount("produsent5", 4))
         return statusoppdateringInternSession
     }
 
-    fun giveMeACacheSessionWithConfiguration(type: EventType, config: Map<String, Int>): CacheCountingMetricsSession {
+    fun giveMeACacheSessionWithConfiguration(type: EventType, config: Map<Producer, Int>): CacheCountingMetricsSession {
         val session = CacheCountingMetricsSession(type)
 
-        session.addEventsByProducer(config)
+        val counts = config.entries.map { (producer, count) ->
+            EventCountForProducer(producer.namespace, producer.appName, count)
+        }
+
+        session.addEventsByProducer(counts)
 
         return session
     }
+
+    private fun createCount(producerAppName: String, count: Int) = listOf(EventCountForProducer(defaultNamespace, producerAppName, count))
 }

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheCountingMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/cache/count/CacheCountingMetricsSessionTest.kt
@@ -1,31 +1,32 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.cache.count
 
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.EventCountForProducer
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldContainAll
 import org.junit.jupiter.api.Test
 
 internal class CacheCountingMetricsSessionTest {
 
-    val beskjederGruppertPerProdusent = mutableMapOf<String, Int>()
-    val produsent1 = "produsent1"
-    val produsent2 = "produsent2"
-    val produsent3 = "produsent3"
+    val produsent1 = Producer("namespace1","produsent1")
+    val produsent2 = Producer("namespace2","produsent2")
+    val produsent3 = Producer("namespace3","produsent3")
     val produsent1Antall = 1
     val produsent2Antall = 2
     val produsent3Antall = 3
+    val producerCounts = listOf(
+        EventCountForProducer(produsent1.namespace, produsent1.appName, produsent1Antall),
+        EventCountForProducer(produsent2.namespace, produsent2.appName, produsent2Antall),
+        EventCountForProducer(produsent3.namespace, produsent3.appName, produsent3Antall)
+    )
     val alleProdusenter = listOf(produsent1, produsent2, produsent3)
 
-    init {
-        beskjederGruppertPerProdusent[produsent1] = produsent1Antall
-        beskjederGruppertPerProdusent[produsent2] = produsent2Antall
-        beskjederGruppertPerProdusent[produsent3] = produsent3Antall
-    }
 
     @Test
     fun `Skal telle opp riktig totalantall eventer, og rapportere riktig per produsent`() {
         val session = CacheCountingMetricsSession(EventType.BESKJED_INTERN)
-        session.addEventsByProducer(beskjederGruppertPerProdusent)
+        session.addEventsByProducer(producerCounts)
 
         session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall)
         session.getNumberOfEvents() `should be equal to` session.getTotalNumber()
@@ -41,8 +42,8 @@ internal class CacheCountingMetricsSessionTest {
     @Test
     fun `Skal telle opp riktig totalantall eventer, hvis eventer legges til flere ganger`() {
         val session = CacheCountingMetricsSession(EventType.BESKJED_INTERN)
-        session.addEventsByProducer(beskjederGruppertPerProdusent)
-        session.addEventsByProducer(beskjederGruppertPerProdusent)
+        session.addEventsByProducer(producerCounts)
+        session.addEventsByProducer(producerCounts)
 
         session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall) * 2
 

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicEventTypeCounterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicEventTypeCounterTest.kt
@@ -52,9 +52,9 @@ internal class TopicEventTypeCounterTest {
         val minimumProcessingTimeInMs: Long = 500
 
         every { TopicEventTypeCounter.countBatch(polledEvents, capture(sessionSlot)) } coAnswers {
-            sessionSlot.captured.countEvent(KafkaEventIdentifier("1", "test"))
-            sessionSlot.captured.countEvent(KafkaEventIdentifier("2", "test"))
-            sessionSlot.captured.countEvent(KafkaEventIdentifier("3", "test"))
+            sessionSlot.captured.countEvent(KafkaEventIdentifier("1", "test", "test"))
+            sessionSlot.captured.countEvent(KafkaEventIdentifier("2", "test", "test"))
+            sessionSlot.captured.countEvent(KafkaEventIdentifier("3", "test", "test"))
             delay(minimumProcessingTimeInMs)
         }
 

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsReporterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsReporterTest.kt
@@ -32,9 +32,9 @@ internal class TopicMetricsReporterTest {
         coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForTotalEventsByProducer), any()) } returns Unit
 
         val session = TopicMetricsSession(EventType.BESKJED_INTERN)
-        session.countEvent(KafkaEventIdentifier("1", "producer"))
-        session.countEvent(KafkaEventIdentifier("2", "producer"))
-        session.countEvent(KafkaEventIdentifier("3", "producer"))
+        session.countEvent(KafkaEventIdentifier("1",  "namespace", "producer"))
+        session.countEvent(KafkaEventIdentifier("2",  "namespace", "producer"))
+        session.countEvent(KafkaEventIdentifier("3",  "namespace", "producer"))
         runBlocking {
             topicMetricsReporter.report(session)
         }
@@ -55,7 +55,7 @@ internal class TopicMetricsReporterTest {
         coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, capture(capturedFieldsForProcessingTime), any()) } returns Unit
 
         val session = TopicMetricsSession(EventType.BESKJED_INTERN)
-        session.countEvent(KafkaEventIdentifier("1", "dummyAppnavn"))
+        session.countEvent(KafkaEventIdentifier("1", "dummyNamespace", "dummyAppnavn"))
         runBlocking { delay(expectedProcessingTimeMs) }
         session.calculateProcessingTime()
         runBlocking {
@@ -69,22 +69,23 @@ internal class TopicMetricsReporterTest {
 
     @Test
     fun `Should use the provided appname as producername`() {
-        val producerName = "dummyAppnavn"
+        val producerApp = "dummyAppnavn"
+        val producerNamespace = "dummyAppnavn"
 
         val capturedTagsForTotalByProducer = slot<Map<String, String>>()
 
         coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
 
         val session = TopicMetricsSession(EventType.BESKJED_INTERN)
-        session.countEvent(KafkaEventIdentifier("1", producerName))
-        session.countEvent(KafkaEventIdentifier("2", producerName))
+        session.countEvent(KafkaEventIdentifier("1", producerNamespace, producerApp))
+        session.countEvent(KafkaEventIdentifier("2", producerNamespace, producerApp))
         runBlocking {
             topicMetricsReporter.report(session)
         }
 
         coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) }
 
-        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerName
+        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerApp
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
@@ -1,129 +1,130 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.topic
 
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.KafkaEventIdentifier
 
 object TopicMetricsSessionObjectMother {
 
     fun giveMeBeskjedSessionWithOneCountedEvent(): TopicMetricsSession {
         val beskjedSession = TopicMetricsSession(EventType.BESKJED_INTERN)
-        beskjedSession.countEvent(KafkaEventIdentifier("1", "dummyAppnavn"))
+        beskjedSession.countEvent(KafkaEventIdentifier("1", "dummyNamespace", "dummyAppnavn"))
         return beskjedSession
     }
 
     fun giveMeBeskjedSessionWithTwoCountedEvents(): TopicMetricsSession {
         val beskjedSession = TopicMetricsSession(EventType.BESKJED_INTERN)
-        beskjedSession.countEvent(KafkaEventIdentifier("21", "dummyAppnavn"))
-        beskjedSession.countEvent(KafkaEventIdentifier("22", "dummyAppnavn"))
+        beskjedSession.countEvent(KafkaEventIdentifier("21", "dummyNamespace", "dummyAppnavn"))
+        beskjedSession.countEvent(KafkaEventIdentifier("22", "dummyNamespace", "dummyAppnavn"))
         return beskjedSession
     }
 
     fun giveMeBeskjedInternSessionWithTwoCountedEvents(): TopicMetricsSession {
         val beskjedInternSession = TopicMetricsSession(EventType.BESKJED_INTERN)
-        beskjedInternSession.countEvent(KafkaEventIdentifier("21", "dummyAppnavn"))
-        beskjedInternSession.countEvent(KafkaEventIdentifier("22", "dummyAppnavn"))
+        beskjedInternSession.countEvent(KafkaEventIdentifier("21", "dummyNamespace", "dummyAppnavn"))
+        beskjedInternSession.countEvent(KafkaEventIdentifier("22", "dummyNamespace", "dummyAppnavn"))
         return beskjedInternSession
     }
 
     fun giveMeDoneSessionWithOneCountedEvent(): TopicMetricsSession {
         val doneSession = TopicMetricsSession(EventType.DONE_INTERN)
-        doneSession.countEvent(KafkaEventIdentifier("21", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("21", "dummyNamespace", "dummyAppnavn"))
         return doneSession
     }
 
     fun giveMeDoneSessionWithThreeCountedEvent(): TopicMetricsSession {
         val doneSession = TopicMetricsSession(EventType.DONE_INTERN)
-        doneSession.countEvent(KafkaEventIdentifier("31", "dummyAppnavn"))
-        doneSession.countEvent(KafkaEventIdentifier("32", "dummyAppnavn"))
-        doneSession.countEvent(KafkaEventIdentifier("33", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("31", "dummyNamespace", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("32", "dummyNamespace", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("33", "dummyNamespace", "dummyAppnavn"))
         return doneSession
     }
 
     fun giveMeDoneInternSessionWithThreeCountedEvent(): TopicMetricsSession {
         val doneSession = TopicMetricsSession(EventType.DONE_INTERN)
-        doneSession.countEvent(KafkaEventIdentifier("31", "dummyAppnavn"))
-        doneSession.countEvent(KafkaEventIdentifier("32", "dummyAppnavn"))
-        doneSession.countEvent(KafkaEventIdentifier("33", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("31", "dummyNamespace", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("32", "dummyNamespace", "dummyAppnavn"))
+        doneSession.countEvent(KafkaEventIdentifier("33", "dummyNamespace", "dummyAppnavn"))
         return doneSession
     }
 
     fun giveMeInnboksSessionWithOneCountedEvent(): TopicMetricsSession {
         val innboksSession = TopicMetricsSession(EventType.INNBOKS_INTERN)
-        innboksSession.countEvent(KafkaEventIdentifier("31", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("31", "dummyNamespace", "dummyAppnavn"))
         return innboksSession
     }
 
     fun giveMeInnboksSessionWithFourCountedEvent(): TopicMetricsSession {
         val innboksSession = TopicMetricsSession(EventType.INNBOKS_INTERN)
-        innboksSession.countEvent(KafkaEventIdentifier("41", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("42", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("43", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("44", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("41", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("42", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("43", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("44", "dummyNamespace", "dummyAppnavn"))
         return innboksSession
     }
 
     fun giveMeInnboksInternSessionWithFourCountedEvent(): TopicMetricsSession {
         val innboksSession = TopicMetricsSession(EventType.INNBOKS_INTERN)
-        innboksSession.countEvent(KafkaEventIdentifier("41", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("42", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("43", "dummyAppnavn"))
-        innboksSession.countEvent(KafkaEventIdentifier("44", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("41", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("42", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("43", "dummyNamespace", "dummyAppnavn"))
+        innboksSession.countEvent(KafkaEventIdentifier("44", "dummyNamespace", "dummyAppnavn"))
         return innboksSession
     }
 
     fun giveMeOppgaveSessionWithOneCountedEvent(): TopicMetricsSession {
         val oppgaveSession = TopicMetricsSession(EventType.OPPGAVE_INTERN)
-        oppgaveSession.countEvent(KafkaEventIdentifier("41", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("41", "dummyNamespace", "dummyAppnavn"))
         return oppgaveSession
     }
 
     fun giveMeOppgaveSessionWithFiveCountedEvent(): TopicMetricsSession {
         val oppgaveSession = TopicMetricsSession(EventType.OPPGAVE_INTERN)
-        oppgaveSession.countEvent(KafkaEventIdentifier("51", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("52", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("53", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("54", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("55", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("51", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("52", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("53", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("54", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("55", "dummyNamespace", "dummyAppnavn"))
         return oppgaveSession
     }
 
     fun giveMeOppgaveInternSessionWithFiveCountedEvent(): TopicMetricsSession {
         val oppgaveSession = TopicMetricsSession(EventType.OPPGAVE_INTERN)
-        oppgaveSession.countEvent(KafkaEventIdentifier("51", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("52", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("53", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("54", "dummyAppnavn"))
-        oppgaveSession.countEvent(KafkaEventIdentifier("55", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("51", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("52", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("53", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("54", "dummyNamespace", "dummyAppnavn"))
+        oppgaveSession.countEvent(KafkaEventIdentifier("55", "dummyNamespace", "dummyAppnavn"))
         return oppgaveSession
     }
 
     fun giveMeStatusoppdateringSessionWithOneCountedEvent(): TopicMetricsSession {
         val statusoppdateringSession = TopicMetricsSession(EventType.STATUSOPPDATERING_INTERN)
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyNamespace", "dummyAppnavn"))
         return statusoppdateringSession
     }
 
     fun giveMeStatusoppdateringSessionWithFiveCountedEvent(): TopicMetricsSession {
         val statusoppdateringSession = TopicMetricsSession(EventType.STATUSOPPDATERING_INTERN)
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("62", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("63", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("64", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("65", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("62", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("63", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("64", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("65", "dummyNamespace", "dummyAppnavn"))
         return statusoppdateringSession
     }
 
     fun giveMeStatusoppdateringInternSessionWithFiveCountedEvent(): TopicMetricsSession {
         val statusoppdateringSession = TopicMetricsSession(EventType.STATUSOPPDATERING_INTERN)
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("62", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("63", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("64", "dummyAppnavn"))
-        statusoppdateringSession.countEvent(KafkaEventIdentifier("65", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("61", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("62", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("63", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("64", "dummyNamespace", "dummyAppnavn"))
+        statusoppdateringSession.countEvent(KafkaEventIdentifier("65", "dummyNamespace", "dummyAppnavn"))
         return statusoppdateringSession
     }
 
-    fun giveMeATopicSessionWithConfiguration(type: EventType, config: Map<String, Int>): TopicMetricsSession {
+    fun giveMeATopicSessionWithConfiguration(type: EventType, config: Map<Producer, Int>): TopicMetricsSession {
         val session = TopicMetricsSession(type)
 
         unrollAndTransformToEvents(config).forEach { event ->
@@ -133,18 +134,18 @@ object TopicMetricsSessionObjectMother {
         return session
     }
 
-    private fun unrollAndTransformToEvents(configs: Map<String, Int>): List<KafkaEventIdentifier> {
+    private fun unrollAndTransformToEvents(configs: Map<Producer, Int>): List<KafkaEventIdentifier> {
 
         return configs.entries
             .map { transformToEvents(it) }
             .flatten()
     }
 
-    private fun transformToEvents(entry: Map.Entry<String, Int>): List<KafkaEventIdentifier> {
+    private fun transformToEvents(entry: Map.Entry<Producer, Int>): List<KafkaEventIdentifier> {
         val (producer, numberOfEvents) = entry
 
         return (0 until numberOfEvents).map { index ->
-            KafkaEventIdentifier("$producer-$index", producer)
+            KafkaEventIdentifier("$producer-$index", producer.namespace, producer.appName)
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/internal/periodic/metrics/reporter/metrics/kafka/topic/TopicMetricsSessionTest.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.topic
 
 import no.nav.personbruker.internal.periodic.metrics.reporter.config.EventType
+import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.Producer
 import no.nav.personbruker.internal.periodic.metrics.reporter.metrics.kafka.KafkaEventIdentifier
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should not be equal to`
@@ -8,9 +9,9 @@ import org.junit.jupiter.api.Test
 
 internal class TopicMetricsSessionTest {
 
-    val produsent1 = "p-1"
-    val produsent2 = "p-2"
-    val produsent3 = "p-3"
+    val produsent1 = Producer("namespace1", "p-1")
+    val produsent2 = Producer("namespace2", "p-2")
+    val produsent3 = Producer("namespace3", "p-3")
 
     @Test
     fun `Skal summere opp eventer riktig i hver kategori per produsent`() {
@@ -46,9 +47,9 @@ internal class TopicMetricsSessionTest {
 
         val other = TopicMetricsSession(originalMetricsSession)
 
-        val produsent1Event2 = KafkaEventIdentifier("b-2", produsent1)
-        val produsent2Event3 = KafkaEventIdentifier("b-13", produsent2)
-        val produsent2Event4 = KafkaEventIdentifier("b-14", produsent2)
+        val produsent1Event2 = KafkaEventIdentifier("b-2", produsent1.namespace, produsent1.appName)
+        val produsent2Event3 = KafkaEventIdentifier("b-13", produsent2.namespace, produsent2.appName)
+        val produsent2Event4 = KafkaEventIdentifier("b-14", produsent2.namespace, produsent2.appName)
 
         other.countEvent(produsent1Event2)
         other.countEvent(produsent2Event3)
@@ -66,12 +67,12 @@ internal class TopicMetricsSessionTest {
 
         val metricsSession = TopicMetricsSession(EventType.BESKJED_INTERN)
 
-        val produsent1Event1 = KafkaEventIdentifier("b-1", produsent1)
-        val produsent2Event1 = KafkaEventIdentifier("b-11", produsent2)
-        val produsent2Event2 = KafkaEventIdentifier("b-12", produsent2)
-        val produsent3Event1 = KafkaEventIdentifier("b-21", produsent3)
-        val produsent3Event2 = KafkaEventIdentifier("b-22", produsent3)
-        val produsent3Event3 = KafkaEventIdentifier("b-23", produsent3)
+        val produsent1Event1 = KafkaEventIdentifier("b-1", produsent1.namespace, produsent1.appName)
+        val produsent2Event1 = KafkaEventIdentifier("b-11", produsent2.namespace, produsent2.appName)
+        val produsent2Event2 = KafkaEventIdentifier("b-12", produsent2.namespace, produsent2.appName)
+        val produsent3Event1 = KafkaEventIdentifier("b-21", produsent3.namespace, produsent3.appName)
+        val produsent3Event2 = KafkaEventIdentifier("b-22", produsent3.namespace, produsent3.appName)
+        val produsent3Event3 = KafkaEventIdentifier("b-23", produsent3.namespace, produsent3.appName)
 
 
         metricsSession.countEvent(produsent1Event1)


### PR DESCRIPTION
Oppdaterer metrikker slik at det bruker appnavn/namespace i stedet for systembruker.

Denne er avhenging av [denne](https://github.com/navikt/dittnav-event-handler/pull/117) PR-en.